### PR TITLE
fix: update logger to not redact lines with more than 16 total digits

### DIFF
--- a/__test__/unit/util/logger.spec.ts
+++ b/__test__/unit/util/logger.spec.ts
@@ -29,6 +29,21 @@ describe('Kibo PaymentGateway Hosting - Logger', () => {
     expect(resultInfo).toEqual(expectMessage)
   })
 
+  it('should not redact a GUID with more than 16 numberic characters', () => {
+    const info = {
+      level: 'info',
+      message: 'Your random guid is 309091E0-231A-43E1-AE32-52347E85C7F4',
+    }
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(info)
+  })
+
+  it('should not redact a message with 16 digits interspaced with other alphabetic characters', () => {
+    const info = { level: 'info', message: 'Id 4242, User 4242, Code 4242, Country 4242' }
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(info)
+  })
+
   it('should log json formatted info level message', () => {
     const expected = `{"level":"info","message":"this is a log message"}`
 

--- a/__test__/unit/util/logger.spec.ts
+++ b/__test__/unit/util/logger.spec.ts
@@ -22,6 +22,55 @@ describe('Kibo PaymentGateway Hosting - Logger', () => {
     expect(resultInfo).toEqual(expectMessage)
   })
 
+  it('should should redact a MasterCard card', () => {
+    const info = { level: 'info', message: 'Your card number is 5555555555554444' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a American Express card', () => {
+    const info = { level: 'info', message: 'Your card number is 371449635398431' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a American Express with dashes', () => {
+    const info = { level: 'info', message: 'Your card number is 3714-4963-5398-431' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a Diners Club card', () => {
+    const info = { level: 'info', message: 'Your card number is 36227206271667' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a Discover card', () => {
+    const info = { level: 'info', message: 'Your card number is 6011000990139424' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a JCB card', () => {
+    const info = { level: 'info', message: 'Your card number is 3566002020360505' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
+  it('should should redact a JCB with dashes', () => {
+    const info = { level: 'info', message: 'Your card number is 3566-0020-2036-0505' }
+    const expectMessage = false
+    const resultInfo = redactPciMessage(info)
+    expect(resultInfo).toEqual(expectMessage)
+  })
+
   it('should set message to redacted for containing 16 digit number with hypens', () => {
     const info = { level: 'info', message: 'Your card number is 4111-1111-1111-1111' }
     const expectMessage = false

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -3,7 +3,7 @@ import type { LoggerOptions } from 'winston'
 import type { TransformFunction } from 'logform'
 import correlator from 'express-correlation-id'
 
-const potentiallyPrivatePattern = /(\d{4}[ -]?){3}\d{4}/
+const potentiallyPrivatePattern = /(\d{4}[ -]?){3}\d{2}\d?\d?/
 const shouldRedactLog = (message: string | Record<string, unknown>) => {
   const str = typeof message === 'object' ? JSON.stringify(message) : message
   return str.match(potentiallyPrivatePattern) ? true : false

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -3,7 +3,7 @@ import type { LoggerOptions } from 'winston'
 import type { TransformFunction } from 'logform'
 import correlator from 'express-correlation-id'
 
-const potentiallyPrivatePattern = /4(?:\D*\d){13,16}/
+const potentiallyPrivatePattern = /(\d{4}[ -]?){3}\d{4}/
 const shouldRedactLog = (message: string | Record<string, unknown>) => {
   const str = typeof message === 'object' ? JSON.stringify(message) : message
   return str.match(potentiallyPrivatePattern) ? true : false


### PR DESCRIPTION
If there were more than 16 digits in the log output, the sensitive data check would get triggered